### PR TITLE
Supports the new version of diffusers. Tested with diffusers==0.27.2.

### DIFF
--- a/diff_latent_attack.py
+++ b/diff_latent_attack.py
@@ -94,7 +94,6 @@ def register_attention_control(model, controller):
             temb: Optional[torch.FloatTensor] = None,
             # scale: float = 1.0,
         ):
-            # print(self.spatial_norm, attention_mask, self.group_norm) # None None None
             if self.spatial_norm is not None:
                 hidden_states = self.spatial_norm(hidden_states, temb)
 


### PR DESCRIPTION
Thanks for your great work. I corrected this version of [DiffAttack](https://github.com/AndPuQing/DiffAttack/tree/main) and tested it with diffusers=0.27.2.

![0000_diff_resnet_image_ATKSuccess](https://github.com/user-attachments/assets/61d905f1-8286-4151-8a1a-04c47570683c)
